### PR TITLE
Allow grouping sitemaps on the index by a unique name

### DIFF
--- a/lib/xml-sitemap/index.rb
+++ b/lib/xml-sitemap/index.rb
@@ -3,8 +3,8 @@ module XmlSitemap
     attr_reader :maps
     
     def initialize(opts={})
-      @maps   = []
-      @offset = 0
+      @maps     = []
+      @offsets  = Hash.new(0)
       
       yield self if block_given?
     end
@@ -15,10 +15,10 @@ module XmlSitemap
       raise ArgumentError, 'Map is empty!' if map.empty?
       
       @maps << {
-        :loc     => map.index_url(@offset),
+        :loc     => map.index_url(@offsets[map.group]),
         :lastmod => map.created_at.utc.iso8601
       }
-      @offset += 1
+      @offsets[map.group] += 1
     end
     
     # Generate sitemap XML index

--- a/lib/xml-sitemap/map.rb
+++ b/lib/xml-sitemap/map.rb
@@ -23,6 +23,7 @@ module XmlSitemap
     attr_reader   :buffer
     attr_reader   :created_at
     attr_reader   :root
+    attr_reader   :group
     
     # Creates new Map class for specified domain
     def initialize(domain, opts={})
@@ -33,6 +34,7 @@ module XmlSitemap
       @secure     = opts[:secure] || false
       @home       = opts.key?(:home) ? opts[:home] : true
       @root       = opts.key?(:root) ? opts[:root] : true
+      @group      = opts[:group] || "sitemap"
       @items      = []
       
       self.add('/', :priority => 1.0) if @home === true
@@ -75,7 +77,7 @@ module XmlSitemap
     
     # Get full url for index
     def index_url(offset)
-      "http://#{@domain}/sitemap-#{offset}.xml"
+      "http://#{@domain}/#{@group}-#{offset}.xml"
     end
     
     # Render XML

--- a/spec/fixtures/group_index.xml
+++ b/spec/fixtures/group_index.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>http://foobar.com/first-0.xml</loc>
+    <lastmod>2011-06-01T00:00:01Z</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>http://foobar.com/second-0.xml</loc>
+    <lastmod>2011-06-01T00:00:01Z</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>http://foobar.com/second-1.xml</loc>
+    <lastmod>2011-06-01T00:00:01Z</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>http://foobar.com/third-0.xml</loc>
+    <lastmod>2011-06-01T00:00:01Z</lastmod>
+  </sitemap>
+</urlset>

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -47,4 +47,24 @@ describe XmlSitemap::Index do
     File.read(path).should == fixture('sample_index.xml')
     File.delete(path) if File.exists?(path)
   end
+  
+  it 'should have separate running offsets for different map groups' do
+    m1 = XmlSitemap::Map.new('foobar.com', :time => @base_time, :group => "first")  { |m| m.add('about') }
+    m2 = XmlSitemap::Map.new('foobar.com', :time => @base_time, :group => "second") { |m| m.add('about') }
+    m3 = XmlSitemap::Map.new('foobar.com', :time => @base_time, :group => "second") { |m| m.add('about') }
+    m4 = XmlSitemap::Map.new('foobar.com', :time => @base_time, :group => "third")  { |m| m.add('about') }
+    
+    index = XmlSitemap::Index.new do |i|
+      i.add(m1)
+      i.add(m2)
+      i.add(m3)
+      i.add(m4)
+    end
+    
+    path = "/tmp/index_#{Time.now.to_i}.xml"
+    index.render_to(path)
+    File.read(path).should == fixture('group_index.xml')
+    File.delete(path) if File.exists?(path)
+  end
+  
 end


### PR DESCRIPTION
In our use case, we want to group sitemaps in the sitemap index by a unique name, each having its own offset count.

eg.   red-0, red-1, blue-0 ...

This pull request contains a :group option you can provide to the Map object which is expected to be a string that will be used to override the normal "sitemap" name, as well as used as a key to an offsets hash (replacing the offset count) in the Index.  The value is the offset count for that group.  In the default case, you still get sitemap-0, sitemap-1, etc.  I have included tests, let me know if you have any comments.

Thanks for the excellent project.
