### PR TITLE
Allow strings on :updated option

### DIFF
--- a/lib/xml-sitemap/map.rb
+++ b/lib/xml-sitemap/map.rb
@@ -2,24 +2,39 @@ module XmlSitemap
   class Item
     DEFAULT_PRIORITY = 0.5
     
-    attr_reader :target, :updated, :priority, :changefreq
+    # ISO8601 regex from here: http://www.pelagodesign.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
+    ISO8601_REGEX = /^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/
+    
+    attr_reader :target, :updated, :priority, :changefreq, :validate_time
     
     def initialize(target, opts={})
-      @target     = target.to_s.strip
-      @updated    = opts[:updated]  || Time.now
-      @priority   = opts[:priority] || DEFAULT_PRIORITY
-      @changefreq = opts[:period]   || :weekly
+      @target         = target.to_s.strip
+      @updated        = opts[:updated]  || Time.now
+      @priority       = opts[:priority] || DEFAULT_PRIORITY
+      @changefreq     = opts[:period]   || :weekly
+      @validate_time  = (opts[:validate_time] != false)
       
-      # allow only date or time object
-      unless @updated.kind_of?(Time) || @updated.kind_of?(Date)
-        raise ArgumentError, "Time or Date required for :updated!"
+      unless @updated.kind_of?(Time) || @updated.kind_of?(Date) || @updated.kind_of?(String)
+        raise ArgumentError, "Time, Date, or ISO8601 String required for :updated!"
       end
       
-      # use full time and date only!
+      if @validate_time && @updated.kind_of?(String) && !(@updated =~ ISO8601_REGEX)
+        raise ArgumentError, "String provided to :updated did not match ISO8601 standard!"
+      end
+      
       @updated = @updated.to_time if @updated.kind_of?(Date)
     end
+    
+    def lastmod_value
+      if (@updated.is_a? Time)
+        @updated.utc.iso8601
+      else
+        @updated.to_s
+      end
+    end
+    
   end
-
+  
   class Map
     attr_reader   :domain, :items
     attr_reader   :buffer
@@ -96,7 +111,7 @@ module XmlSitemap
         @items.each do |item|
           s.url do |u|
             u.loc        item.target
-            u.lastmod    item.updated.utc.iso8601
+            u.lastmod    item.lastmod_value
             u.changefreq item.changefreq.to_s
             u.priority   item.priority.to_s
           end

--- a/spec/map_spec.rb
+++ b/spec/map_spec.rb
@@ -54,8 +54,27 @@ describe XmlSitemap::Map do
   
   it 'should raise Argument error if no time or date were provided' do
     map = XmlSitemap::Map.new('foobar.com', :time => @base_time)
+    proc { map.add('hello', :updated => 5) }.
+      should raise_error ArgumentError, "Time, Date, or ISO8601 String required for :updated!"
+  end
+  
+  it 'should not raise Argument error if a iso8601 string is provided' do
+    map = XmlSitemap::Map.new('foobar.com', :time => @base_time)
+    proc { map.add('hello', :updated => "2011-09-12T23:18:49Z") }.
+      should_not raise_error
+    map.add('world', :updated => @extra_time.utc.iso8601).updated.should == Time.gm(2011, 7, 1, 0, 0, 1).utc.iso8601
+  end
+  
+  it 'should not raise Argument error if a string is provided with :validate_time => false' do
+    map = XmlSitemap::Map.new('foobar.com', :time => @base_time)
+    proc { map.add('hello', :validate_time => false, :updated => 'invalid data') }.
+      should_not raise_error
+  end
+  
+  it 'should raise Argument error if an invalid string is provided' do
+    map = XmlSitemap::Map.new('foobar.com', :time => @base_time)
     proc { map.add('hello', :updated => 'invalid data') }.
-      should raise_error ArgumentError, "Time or Date required for :updated!"
+      should raise_error ArgumentError, "String provided to :updated did not match ISO8601 standard!"
   end
   
   it 'should have properly encoded entities' do


### PR DESCRIPTION
Hi again,

  I noticed that you are enforcing the use of a Time or Date object for the :updated (aka lastmod) field, so that you can do .utc.iso8601 on the resulting object.

  I am using this gem with rails, with very large MySQL tables, trying to set lastmod from a time field.  It turns out that ActiveRecord converting the string in the DB to a Time (and then back to a string inside this gem) is one of the slowest aspects of my code.  Since my time is already a string, I want to be able to input a string directly into this option (perhaps after some manual ISO8601 reformatting).

  Checking that string for iso8601 compliance via Time.parse would undo the optimization, so that is not really an option.  Also, I am not sure if there are any other canonical options for iso8601 validation.  I don't want to introduce a giant regex in this gem, for example.

  How do you think we can approach this issue?  If the answer is to simply allow strings without validation, I can commit those changes.

Thanks,
--Dan
