### PR TITLE
Alternatives to using Builder for performance reasons

### DIFF
--- a/lib/xml-sitemap.rb
+++ b/lib/xml-sitemap.rb
@@ -2,7 +2,10 @@ require 'time'
 require 'date'
 require 'zlib'
 require 'builder'
-require 'nokogiri'
+begin
+  require 'nokogiri'
+rescue LoadError
+end
 
 require 'xml-sitemap/options'
 require 'xml-sitemap/map'

--- a/spec/map_spec.rb
+++ b/spec/map_spec.rb
@@ -61,7 +61,7 @@ describe XmlSitemap::Map do
     end
     
     Benchmark.bm do |x|
-      x.report("render")            { map.render }
+      x.report("render(:builder)")  { map.render(:builder)  }
       x.report("render(:nokogiri)") { map.render(:nokogiri) }
       x.report("render(:string)")   { map.render(:string)   }
     end

--- a/xml-sitemap.gemspec
+++ b/xml-sitemap.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',      '~> 0.8'
   s.add_development_dependency 'rspec',     '~> 2.6'
   s.add_development_dependency 'simplecov', '~> 0.4'
+  s.add_development_dependency 'nokogiri',  '~> 1.5.0'
   
   s.add_runtime_dependency      'builder',  '>= 2.0'
-  s.add_runtime_dependency      'nokogiri', '~> 1.5.0'
   
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
I have another performance-related suggestion...

I benchmarked Builder's performance against Nokogiri and raw string concatenation.  For ~50k entries:
                        user     system      total        real
render             17.680000   0.050000  17.730000 ( 17.726192)
render(:nokogiri)   8.180000   0.140000   8.320000 (  8.327214)
render(:string)     1.560000   0.030000   1.590000 (  1.580630)

I implemented them as options to the render method:

render(:nokogiri) will use nokogiri
render(:string) will use raw string concatenation

Let me know if this sounds like a good patch or if you have any other ideas (like just replacing Builder).  It's on the performance branch on my fork:  

https://github.com/danhealy/xml-sitemap/tree/performance
