### PR TITLE
Enable the secure option for sitemap indexes

### DIFF
--- a/lib/xml-sitemap/index.rb
+++ b/lib/xml-sitemap/index.rb
@@ -4,9 +4,14 @@ module XmlSitemap
     
     # Initialize a new Index instance
     #
+    # opts   - Index options
+    #
+    # opts[:secure] - Force HTTPS for all items. (default: false)
+    #
     def initialize(opts={})
       @maps     = []
       @offsets  = Hash.new(0)
+      @secure   = opts[:secure] || false
       
       yield self if block_given?
     end
@@ -20,7 +25,7 @@ module XmlSitemap
       raise ArgumentError, 'Map is empty!' if map.empty?
       
       @maps << {
-        :loc     => map.index_url(@offsets[map.group]),
+        :loc     => map.index_url(@offsets[map.group], @secure),
         :lastmod => map.created_at.utc.iso8601
       }
       @offsets[map.group] += 1

--- a/lib/xml-sitemap/map.rb
+++ b/lib/xml-sitemap/map.rb
@@ -83,8 +83,8 @@ module XmlSitemap
     
     # Get full url for index
     #
-    def index_url(offset)
-      "http://#{@domain}/#{@group}-#{offset}.xml"
+    def index_url(offset, secure)
+      "#{secure ? 'https' : 'http'}://#{@domain}/#{@group}-#{offset}.xml"
     end
     
     # Render XML

--- a/spec/fixtures/sample_index_secure.xml
+++ b/spec/fixtures/sample_index_secure.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://foobar.com/sitemap-0.xml</loc>
+    <lastmod>2011-06-01T00:00:01Z</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://foobar.com/sitemap-1.xml</loc>
+    <lastmod>2011-06-01T00:00:01Z</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -33,6 +33,18 @@ describe XmlSitemap::Index do
 
       index.render.split("\n")[2..-1].join("\n").should == fixture('sample_index.xml').split("\n")[2..-1].join("\n")
     end
+
+    it 'renders a proper index with the secure option' do
+      m1 = XmlSitemap::Map.new('foobar.com', :time => base_time) { |m| m.add('about') }
+      m2 = XmlSitemap::Map.new('foobar.com', :time => base_time) { |m| m.add('about') }
+
+      index = XmlSitemap::Index.new(:secure => true) do |i|
+        i.add(m1)
+        i.add(m2)
+      end
+
+      index.render.split("\n")[2..-1].join("\n").should == fixture('sample_index_secure.xml').split("\n")[2..-1].join("\n")
+    end
   end
 
   describe '#render_to' do


### PR DESCRIPTION
Our site has all pages served over https so this pull request enables the gem to generate the index files pointing to sitemaps on https also.
