### PR TITLE
Use binary mode to write encoded files

### DIFF
--- a/lib/xml-sitemap/map.rb
+++ b/lib/xml-sitemap/map.rb
@@ -1,13 +1,13 @@
-module XmlSitemap  
+module XmlSitemap
   class Map
     include XmlSitemap::RenderEngine
-    
+
     attr_reader   :domain, :items
     attr_reader   :buffer
     attr_reader   :created_at
     attr_reader   :root
     attr_reader   :group
-    
+
     # Initializa a new Map instance
     #
     # domain - Primary domain for the map (required)
@@ -23,19 +23,19 @@ module XmlSitemap
     def initialize(domain, opts={})
       @domain     = domain.to_s.strip
       raise ArgumentError, 'Domain required!' if @domain.empty?
-      
+
       @created_at = opts[:time]   || Time.now.utc
       @secure     = opts[:secure] || false
       @home       = opts.key?(:home) ? opts[:home] : true
       @root       = opts.key?(:root) ? opts[:root] : true
       @group      = opts[:group] || "sitemap"
       @items      = []
-      
+
       self.add('/', :priority => 1.0) if @home === true
-      
+
       yield self if block_given?
     end
-    
+
     # Adds a new item to the map
     #
     # target - Path or url
@@ -45,48 +45,48 @@ module XmlSitemap
     # opts[:period]        - Update frequency. (default - :weekly)
     # opts[:priority]      - Item priority. (default: 0.5)
     # opts[:validate_time] - Skip time validation if want to insert raw strings.
-    # 
+    #
     def add(target, opts={})
       raise RuntimeError, 'Only up to 50k records allowed!' if @items.size > 50000
       raise ArgumentError, 'Target required!' if target.nil?
       raise ArgumentError, 'Target is empty!' if target.to_s.strip.empty?
-      
+
       url = process_target(target)
-      
+
       if url.length > 2048
         raise ArgumentError, "Target can't be longer than 2,048 characters!"
       end
-      
+
       opts[:updated] = @created_at unless opts.key?(:updated)
       item = XmlSitemap::Item.new(url, opts)
       @items << item
       item
     end
-    
+
     # Get map items count
     #
     def size
       @items.size
     end
-    
+
     # Returns true if sitemap does not have any items
     #
     def empty?
       @items.empty?
     end
-    
+
     # Generate full url for path
     #
     def url(path='')
       "#{@secure ? 'https' : 'http'}://#{@domain}#{path}"
     end
-    
+
     # Get full url for index
     #
     def index_url(offset, secure)
       "#{secure ? 'https' : 'http'}://#{@domain}/#{@group}-#{offset}.xml"
     end
-    
+
     # Render XML
     #
     # method - Pick a render engine (:builder, :nokogiri, :string).
@@ -102,7 +102,7 @@ module XmlSitemap
           render_string
       end
     end
-    
+
     # Render XML sitemap into the file
     #
     # path    - Output filename
@@ -114,15 +114,15 @@ module XmlSitemap
     def render_to(path, options={})
       overwrite = options[:overwrite] == true || true
       compress  = options[:gzip]      == true || false
-      
+
       path = File.expand_path(path)
       path << ".gz" unless path =~ /\.gz\z/i if compress
-      
+
       if File.exists?(path) && !overwrite
         raise RuntimeError, "File already exists and not overwritable!"
       end
-      
-      File.open(path, 'w') do |f|
+
+      File.open(path, 'wb') do |f|
         unless compress
           f.write(self.render)
         else
@@ -132,9 +132,9 @@ module XmlSitemap
         end
       end
     end
-    
+
     protected
-  
+
     # Process target path or url
     #
     def process_target(str)


### PR DESCRIPTION
Hi there,

I got this error while trying to use xml-sitemap with gzip enabled:  Encoding::UndefinedConversionError: "\x8B" from ASCII-8BIT to UTF-8

This looks like similar issue description http://stackoverflow.com/questions/13909812/error-ruby-on-rails-encodingundefinedconversionerror-in-coursescontrollerat

Opening file for writing in binary mode fixes this. I tried to use it blank sitemap, just xml instruction and urlset with namespaces. Unfortunately I couldn't reproduce this in spec. Hope it helps anyway.
